### PR TITLE
fix: rendering a html element component failed to render child text n…

### DIFF
--- a/packages/vue-hoc/changelog.md
+++ b/packages/vue-hoc/changelog.md
@@ -1,4 +1,7 @@
 # Change Log
+## 0.3.2
+- rendering a html element component (i.e. calling `h('button')`) failed to render child text nodes
+
 ## 0.3.0
 - unknown render props are passed to the component as attributes
 

--- a/packages/vue-hoc/spec/createHOC.spec.js
+++ b/packages/vue-hoc/spec/createHOC.spec.js
@@ -83,3 +83,22 @@ test('provide props to the hoc', t => {
   t.true(vm.$html.includes('from hoc'));
   t.false(vm.$html.includes('foo'));
 });
+
+test('provide string element in a curried hoc should not contain element not provided', t => {
+  const hoc = createHOCc(null, null)('div')
+  const vm = mount(hoc, {
+    slots: {
+      default: 
+        'foo' +
+        '<div>another foo</div>'
+    }
+  });
+
+  t.is(vm.$html,
+    '<div>' +
+      'foo' +
+      '<div>another foo</div>' +
+    '</div>'
+  );
+  t.false(vm.$html.includes('<template>'));
+})

--- a/packages/vue-hoc/spec/createHOC.spec.js
+++ b/packages/vue-hoc/spec/createHOC.spec.js
@@ -83,22 +83,3 @@ test('provide props to the hoc', t => {
   t.true(vm.$html.includes('from hoc'));
   t.false(vm.$html.includes('foo'));
 });
-
-test('provide string element in a curried hoc should not contain element not provided', t => {
-  const hoc = createHOCc(null, null)('div')
-  const vm = mount(hoc, {
-    slots: {
-      default: 
-        'foo' +
-        '<div>another foo</div>'
-    }
-  });
-
-  t.is(vm.$html,
-    '<div>' +
-      'foo' +
-      '<div>another foo</div>' +
-    '</div>'
-  );
-  t.false(vm.$html.includes('<template>'));
-})

--- a/packages/vue-hoc/spec/slots.spec.js
+++ b/packages/vue-hoc/spec/slots.spec.js
@@ -58,43 +58,91 @@ test('it renders multiple slots', t => {
   t.true(vm.$contains('#fourth'));
 });
 
-test('it renders text slot content', t => {
+test('(Component) it renders text slot content', t => {
   const hoc = createHOC(Component);
   const vm = mount(hoc, {
     slots: 'some text',
   });
+  const html = vm.$html;
 
-  t.true(vm.$html.includes('some text'));
+  t.true(html.includes('some text'));
 });
 
-test('it renders a mix of text and tags', t => {
+test('(string) it renders text slot content', t => {
+  const hoc = createHOC('button');
+  const vm = mount(hoc, {
+    slots: 'some text',
+  });
+  const html = vm.$html;
+  t.true(html.includes('some text'));
+});
+
+test('(Component) it renders a mix of text and tags', t => {
   const hoc = createHOC(Component);
   const vm = mount(hoc, {
     slots: 'some text <span id="icon">icon</span> some more text',
   });
+  const html = vm.$html;
 
   t.true(vm.$contains('#icon'));
-  t.true(vm.$html.includes('some text'));
-  t.true(vm.$html.includes('some more text'));
+  t.true(html.includes('some text'));
+  t.true(html.includes('some more text'));
 });
 
-test('it renders a mix of tags and text', t => {
+test('(string) it renders a mix of text and tags', t => {
+  const hoc = createHOC('button');
+  const vm = mount(hoc, {
+    slots: 'some text <span id="icon">icon</span> some more text',
+  });
+  const html = vm.$html;
+
+  t.true(vm.$contains('#icon'));
+  t.true(html.includes('some text'));
+  t.true(html.includes('some more text'));
+});
+
+test('(Component) it renders a mix of tags and text', t => {
   const hoc = createHOC(Component);
   const vm = mount(hoc, {
     slots: '<span id="icon">icon</span> some text',
   });
+  const html = vm.$html;
 
   t.true(vm.$contains('#icon'));
-  t.true(vm.$html.includes('some text'));
+  t.true(html.includes('some text'));
 });
 
-test('it renders a mix of tags text and templates', t => {
+test('(string) it renders a mix of tags and text', t => {
+  const hoc = createHOC('button');
+  const vm = mount(hoc, {
+    slots: '<span id="icon">icon</span> some text',
+  });
+  const html = vm.$html;
+
+  t.true(vm.$contains('#icon'));
+  t.true(html.includes('some text'));
+});
+
+test('(Component) it renders a mix of tags text and templates', t => {
   const hoc = createHOC(Component);
   const vm = mount(hoc, {
     slots: '<span id="icon">icon</span> some text<template><div>some template stuff</div>!</template>',
   });
+  const html = vm.$html;
 
   t.true(vm.$contains('#icon'));
-  t.true(vm.$html.includes('some text'));
-  t.true(vm.$html.includes('some template stuff'));
+  t.true(html.includes('some text'));
+  t.true(html.includes('some template stuff'));
+});
+
+test('(string) it renders a mix of tags text and templates', t => {
+  const hoc = createHOC('button');
+  const vm = mount(hoc, {
+    slots: '<span id="icon">icon</span> some text<template><div>some template stuff</div>!</template>',
+  });
+  const html = vm.$html;
+
+  t.true(vm.$contains('#icon'));
+  t.true(html.includes('some text'));
+  t.true(html.includes('some template stuff'));
 });

--- a/packages/vue-hoc/spec/slots.spec.js
+++ b/packages/vue-hoc/spec/slots.spec.js
@@ -1,7 +1,11 @@
 import test from 'ava';
 import sinon from 'sinon';
 import {mount} from 'vuenit';
-import {createHOC, createRenderFn} from '../src';
+import {
+  createHOC,
+  createRenderFn,
+  createHOCc,
+} from '../src';
 
 const Component = {
   template : `<div>
@@ -145,4 +149,23 @@ test('(string) it renders a mix of tags text and templates', t => {
   t.true(vm.$contains('#icon'));
   t.true(html.includes('some text'));
   t.true(html.includes('some template stuff'));
+});
+
+test('provide string element in a curried hoc should not contain element not provided', t => {
+  const hoc = createHOCc(null, null)('div')
+  const vm = mount(hoc, {
+    slots: {
+      default:
+        'foo' +
+        '<div>another foo</div>'
+    }
+  });
+
+  t.is(vm.$html,
+    '<div>' +
+      'foo' +
+      '<div>another foo</div>' +
+    '</div>'
+  );
+  t.false(vm.$html.includes('<template>'));
 });

--- a/packages/vue-hoc/src/normalizeSlots.js
+++ b/packages/vue-hoc/src/normalizeSlots.js
@@ -1,7 +1,3 @@
-function isTextNode(node) {
-  return node != null && node.text != null && node.isComment === false;
-}
-
 const normalizeSlots = (slots, context) => Object.keys(slots)
   .reduce((arr, key) => {
     slots[key].forEach((vnode) => {

--- a/packages/vue-hoc/src/normalizeSlots.js
+++ b/packages/vue-hoc/src/normalizeSlots.js
@@ -5,21 +5,16 @@ function isTextNode(node) {
 const normalizeSlots = (slots, context) => Object.keys(slots)
   .reduce((arr, key) => {
     let template = false;
-    slots[key].forEach(vnode => {
+    slots[key].forEach((vnode) => {
+      if (isTextNode(vnode) && !template && slots[key].length > 1) {
+        slots[key] = context.$createElement('span', {}, slots[key]);
+      }
       if (!vnode.context) {
-        if (isTextNode(vnode)) {
-          if (!template) {
-            slots[key] = context.$createElement('template', {slot: key}, slots[key]);
-            template = true;
-          }
-        } else {
-          slots[key].context = context;
-
-          if (!vnode.data) {
-            vnode.data = {};
-          }
-          vnode.data.slot = key;
+        slots[key].context = context;
+        if (!vnode.data) {
+          vnode.data = {};
         }
+        vnode.data.slot = key;
       }
     });
     return arr.concat(slots[key]);

--- a/packages/vue-hoc/src/normalizeSlots.js
+++ b/packages/vue-hoc/src/normalizeSlots.js
@@ -4,11 +4,7 @@ function isTextNode(node) {
 
 const normalizeSlots = (slots, context) => Object.keys(slots)
   .reduce((arr, key) => {
-    let template = false;
     slots[key].forEach((vnode) => {
-      if (isTextNode(vnode) && !template && slots[key].length > 1) {
-        slots[key] = context.$createElement('span', {}, slots[key]);
-      }
       if (!vnode.context) {
         slots[key].context = context;
         if (!vnode.data) {


### PR DESCRIPTION
…odes

@linusborg could you take a look at [this issue](https://github.com/jackmellis/vue-hoc/issues/18)?

Basically when rendering a html element (i.e. `h('button')`) and wrapping it in a HOC, it won't render inner `<template>` tags as expected - but these are used extensively to handle text node slots.

My solution isn't ideal as it wraps a `<span>` around the children but I can't seem to come up with any other option.
