### PR TITLE
fix(vue-hoc): mixin props should be overridden by component props

### DIFF
--- a/packages/vue-hoc/spec/props.spec.js
+++ b/packages/vue-hoc/spec/props.spec.js
@@ -211,3 +211,135 @@ test('knows about mixin props', t => {
 
   t.is(html, expected);
 });
+
+test('overrides mixin props with component-level props', t => {
+  const C = Object.assign({}, Component, {
+    props: {
+      mixinProp: {
+        default: 'from-component',
+      },
+    },
+    mixins: [
+      {
+        props: {
+          mixinProp: {
+            default: 'from-mixin',
+          },
+        },
+      },
+    ],
+  });
+  const withCreated = createHOCc({
+    created(){
+      t.is(this.mixinProp, 'from-component');
+    },
+  });
+  const hoc = withCreated(C);
+
+  const html = mount(hoc).$html;
+
+  const expected = '<ul><li></li><li></li></ul>';
+
+  t.is(html, expected);
+});
+
+test('overrides component props with hoc props', t => {
+  const C = Object.assign({}, Component, {
+    props: {
+      mixinProp: {
+        default: 'from-component',
+      },
+    },
+    mixins: [
+      {
+        props: {
+          mixinProp: {
+            default: 'from-mixin',
+          },
+        },
+      },
+    ],
+  });
+  const withCreated = createHOCc({
+    props: {
+      mixinProp: {
+        default: 'from-hoc',
+      },
+    },
+    created(){
+      t.is(this.mixinProp, 'from-hoc');
+    },
+  });
+  const hoc = withCreated(C);
+
+  const html = mount(hoc).$html;
+
+  const expected = '<ul><li></li><li></li></ul>';
+
+  t.is(html, expected);
+});
+
+test('it recursively collects mixin props', t => {
+  const C = Object.assign({}, Component, {
+    mixins: [
+      {
+        mixins: [
+          {
+            props: {
+              mixinProp: {
+                default: 'from-deep-mixin',
+              },
+            },
+          },
+        ],
+      },
+    ],
+  });
+  const withCreated = createHOCc({
+    created(){
+      t.is(this.mixinProp, 'from-deep-mixin');
+    },
+  });
+  const hoc = withCreated(C);
+
+  const html = mount(hoc).$html;
+
+  const expected = '<ul><li></li><li></li></ul>';
+
+  t.is(html, expected);
+});
+
+test('it takes the highest mixin prop', t => {
+  const C = Object.assign({}, Component, {
+    mixins: [
+      {
+        props: {
+          mixinProp: {
+            default: 'from-shallow-mixin',
+          },
+        },
+        mixins: [
+          {
+            props: {
+              mixinProp: {
+                default: 'from-deep-mixin',
+              },
+            },
+          },
+        ],
+      },
+    ],
+  });
+  const withCreated = createHOCc({
+    created(){
+      t.is(this.mixinProp, 'from-shallow-mixin');
+    },
+  });
+  const hoc = withCreated(C);
+
+  const html = mount(hoc).$html;
+
+  const expected = '<ul><li></li><li></li></ul>';
+
+  t.is(html, expected);
+});

--- a/packages/vue-hoc/src/getProps.js
+++ b/packages/vue-hoc/src/getProps.js
@@ -17,15 +17,28 @@ const normalize = (props) => {
   return assign({}, props);
 };
 
-export default (Component) => {
-  const options = getComponentOptions(Component);
-  const props = normalize(options.props);
-  const mixins = options.mixins || [];
+const mergeMixinProps = (mixins, initial = {}) => {
+  if (!mixins || !mixins.length) {
+    return initial;
+  }
 
   return mixins.reduce((result, mixin) => {
-    if (!mixin.props) {
-      return result;
-    }
-    return assign({}, result, normalize(mixin.props));
-  }, props);
+    const props = assign(
+      {},
+      mergeMixinProps(mixin.mixins, result),
+      normalize(mixin.props),
+    );
+
+    return assign({}, result, props);
+  }, initial);
 };
+
+const getProps = (Component) => {
+  const options = getComponentOptions(Component);
+  const props = normalize(options.props);
+  const mixinProps = mergeMixinProps(options.mixins);
+
+  return assign({}, mixinProps, props);
+};
+
+export default getProps;


### PR DESCRIPTION
nested mixins should also be pulled into the available props

closes #28